### PR TITLE
Update to set file path to be relative instead of absolute

### DIFF
--- a/src/ZipArchiver.php
+++ b/src/ZipArchiver.php
@@ -51,7 +51,7 @@ class ZipArchiver {
 
                 if ( ! $zip_archive->addFile(
                     $real_filepath,
-                    str_replace( $processed_site_path, '', $filename )
+                    str_replace( $processed_site_path, '.', $filename )
                 )
                 ) {
                     $err = 'Could not add file: ' . $filename;


### PR DESCRIPTION
We are upgrading from a previous version of the plugin and have ran into an issue with where the files are extracting to. 

We have resolved the issue on our installation by making the included change. 