### PR TITLE
Fix redirect error on deleteZip method

### DIFF
--- a/src/Controller.php
+++ b/src/Controller.php
@@ -74,7 +74,7 @@ class Controller {
             unlink( $zip_path );
         }
 
-        wp_safe_redirect( admin_url( 'admin.php?page=wp2static-zip' ) );
+        wp_safe_redirect( admin_url( 'admin.php?page=wp2static-addon-zip' ) );
         exit;
     }
 


### PR DESCRIPTION
Currently when the user deletes the zip file the page doesn't redirect correctly and the user receives a 404 message. This patch fixes this.